### PR TITLE
Fixed `DEFAULT_WEBHOOK_EXPIRATION_MILLISECONDS` and updated tests for `createHmac`

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_URL = 'https://app.jiter.dev/api';
 export const DEFAULT_TIMEOUT = 5000;
-export const DEFAULT_WEBHOOK_EXPIRATION_MILLISECONDS = 1000 * 2; // 2 minutes
+export const DEFAULT_WEBHOOK_EXPIRATION_MILLISECONDS = 1000 * 60 * 2; // 2 minutes
 
 export const SIGNATURE_HEADER = 'X-Jiter-Signature';
 export const REQUEST_TIMESTAMP_HEADER = 'X-Jiter-Request-Timestamp';

--- a/src/utils/signatureIsValid.ts
+++ b/src/utils/signatureIsValid.ts
@@ -15,7 +15,7 @@ export const signatureIsValid: (args: SignatureIsValidArgs) => boolean = ({
   const { signingSecret, millisecondsUntilWebhookExpiration } = getJiterConfig();
   const body = typeof rawBody === 'string' ? rawBody : JSON.stringify(rawBody);
 
-  const timeSinceRequest = Math.abs(Date.now() - Number(Number(requestTimestamp)));
+  const timeSinceRequest = Math.abs(Date.now() - Number(requestTimestamp));
   if (Number.isNaN(timeSinceRequest))
     throw new Error('Invalid request timestamp; request timestamp must be a valid number');
 


### PR DESCRIPTION
### Description of Changes
👆

### Related Issues
<!-- Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
