### PR TITLE
Add encryption

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,8 +29,7 @@
     "no-plusplus": ["error"],
     "no-nested-ternary": ["error"],
     "import/extensions": ["error", "ignorePackages", { "js": "never", "ts": "never" }],
-    "import/prefer-default-export": ["off"],
-    "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"]
+    "import/prefer-default-export": ["off"]
   },
   "settings": {
     "import/resolver": { "node": { "extensions": [".js", ".ts"] } }

--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,8 @@
     "no-plusplus": ["error"],
     "no-nested-ternary": ["error"],
     "import/extensions": ["error", "ignorePackages", { "js": "never", "ts": "never" }],
-    "import/prefer-default-export": ["off"]
+    "import/prefer-default-export": ["off"],
+    "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"]
   },
   "settings": {
     "import/resolver": { "node": { "extensions": [".js", ".ts"] } }

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ const defaultConfigOptions: Required<
   baseUrl: DEFAULT_URL,
   timeout: DEFAULT_TIMEOUT,
   millisecondsUntilWebhookExpiration: DEFAULT_WEBHOOK_EXPIRATION_MILLISECONDS,
+  encryption: null,
 };
 
 let jiterConfig: JiterConfigInstance | undefined;
@@ -15,14 +16,31 @@ export interface JiterInit {
   (config: JiterConfig): void;
   (config: JiterConfig & Partial<OverrideJiterConfigOptions>): void;
 }
+
 /**
  * Initializes the Jiter SDK
  * @params `configOptions` {@link JiterConfigOptions} for initializing your instance of Jiter
  */
 export const init: JiterInit = (jiterConfigOptions) => {
-  jiterConfig = { ...defaultConfigOptions, ...jiterConfigOptions };
+  jiterConfig = { ...defaultConfigOptions, ...jiterConfigOptions, encryption: null };
   if (!jiterConfig.apiKey?.trim()) throw new Error('Invalid API Key');
   if (!jiterConfig.signingSecret?.trim()) throw new Error('Invalid Signing Secret');
+  if (jiterConfigOptions.encryption) {
+    if (jiterConfigOptions.encryption.keys.length === 0) throw new Error('Missing Encryption Keys');
+
+    const ids = new Set<string>();
+    jiterConfig.encryption = {
+      keys: jiterConfigOptions.encryption.keys.map(({ id, key }) => {
+        if (ids.has(id)) throw new Error(`Duplicate Key ID: ${id}`);
+        ids.add(id);
+
+        const keyBuffer = Buffer.from(key, 'hex');
+        if (keyBuffer.byteLength !== 32) throw new Error('Invalid Key Length');
+
+        return { id, key: keyBuffer };
+      }),
+    };
+  }
 };
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,15 +9,13 @@ const defaultConfigOptions: Required<DefaultedJiterConfig> = {
 
 let jiterConfig: JiterConfigInstance | undefined;
 
-export interface JiterInit {
-  (configOptions: JiterConfig): void;
-}
+export type JiterInitFn = (configOptions: JiterConfig) => void;
 
 /**
  * Initializes the Jiter SDK
  * @params `configOptions` {@link JiterConfigOptions} for initializing your instance of Jiter
  */
-export const init: JiterInit = ({ encryption, ...jiterConfigOptions }) => {
+export const init: JiterInitFn = ({ encryption, ...jiterConfigOptions }) => {
   jiterConfig = { ...defaultConfigOptions, ...jiterConfigOptions };
   if (!jiterConfig.apiKey?.trim()) throw new Error('Invalid API Key');
   if (!jiterConfig.signingSecret?.trim()) throw new Error('Invalid Signing Secret');

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,36 +1,32 @@
 import { DEFAULT_WEBHOOK_EXPIRATION_MILLISECONDS, DEFAULT_TIMEOUT, DEFAULT_URL } from './consts';
-import { JiterConfig, JiterConfigInstance, OverrideJiterConfigOptions } from './types/config';
+import { JiterConfigInstance, DefaultedJiterConfig, JiterConfig } from './types/config';
 
-const defaultConfigOptions: Required<
-  Omit<JiterConfig, 'apiKey' | 'signingSecret'> & OverrideJiterConfigOptions
-> = {
+const defaultConfigOptions: Required<DefaultedJiterConfig> = {
   baseUrl: DEFAULT_URL,
   timeout: DEFAULT_TIMEOUT,
   millisecondsUntilWebhookExpiration: DEFAULT_WEBHOOK_EXPIRATION_MILLISECONDS,
-  encryption: null,
 };
 
 let jiterConfig: JiterConfigInstance | undefined;
 
 export interface JiterInit {
-  (config: JiterConfig): void;
-  (config: JiterConfig & Partial<OverrideJiterConfigOptions>): void;
+  (configOptions: JiterConfig): void;
 }
 
 /**
  * Initializes the Jiter SDK
  * @params `configOptions` {@link JiterConfigOptions} for initializing your instance of Jiter
  */
-export const init: JiterInit = (jiterConfigOptions) => {
-  jiterConfig = { ...defaultConfigOptions, ...jiterConfigOptions, encryption: null };
+export const init: JiterInit = ({ encryption, ...jiterConfigOptions }) => {
+  jiterConfig = { ...defaultConfigOptions, ...jiterConfigOptions };
   if (!jiterConfig.apiKey?.trim()) throw new Error('Invalid API Key');
   if (!jiterConfig.signingSecret?.trim()) throw new Error('Invalid Signing Secret');
-  if (jiterConfigOptions.encryption) {
-    if (jiterConfigOptions.encryption.keys.length === 0) throw new Error('Missing Encryption Keys');
+  if (encryption) {
+    if (encryption.keys.length === 0) throw new Error('Missing Encryption Keys');
 
     const ids = new Set<string>();
     jiterConfig.encryption = {
-      keys: jiterConfigOptions.encryption.keys.map(({ id, key }) => {
+      keys: encryption.keys.map(({ id, key }) => {
         if (ids.has(id)) throw new Error(`Duplicate Key ID: ${id}`);
         ids.add(id);
 

--- a/src/events/createEvent.ts
+++ b/src/events/createEvent.ts
@@ -8,17 +8,14 @@ import { CreateEventOptions } from './types/CreateEventOptions';
 /**
  * Create an event
  */
-export const createEvent = async ({
-  disableEncryption,
-  ...createEventOptions
-}: CreateEventOptions) => {
+export const createEvent = async ({ overrides, ...createEventOptions }: CreateEventOptions) => {
   const config = getJiterConfig();
   const response = await getAxios().post<BaseEvent>(
     eventsPath,
     { ...createEventOptions },
     {
       transformRequest: (data: CreateEventOptions) => {
-        if (disableEncryption || !config.encryption) return data;
+        if (overrides?.encryption === false || !config.encryption) return data;
 
         const payload = encrypt(data.payload);
 

--- a/src/events/createEvent.ts
+++ b/src/events/createEvent.ts
@@ -1,4 +1,6 @@
 import { getAxios } from '../axios';
+import { getJiterConfig } from '../config';
+import { encrypt } from '../utils';
 import { eventsPath } from './consts';
 import { BaseEvent } from './types/BaseEvent';
 import { CreateEventOptions } from './types/CreateEventOptions';
@@ -6,7 +8,23 @@ import { CreateEventOptions } from './types/CreateEventOptions';
 /**
  * Create an event
  */
-export const createEvent = async (createEventOptions: CreateEventOptions) => {
-  const response = await getAxios().post<BaseEvent>(eventsPath, { ...createEventOptions });
+export const createEvent = async ({
+  disableEncryption,
+  ...createEventOptions
+}: CreateEventOptions) => {
+  const config = getJiterConfig();
+  const response = await getAxios().post<BaseEvent>(
+    eventsPath,
+    { ...createEventOptions },
+    {
+      transformRequest: (data: CreateEventOptions) => {
+        if (disableEncryption || !config.encryption) return data;
+
+        const payload = encrypt(data.payload);
+
+        return { ...data, payload };
+      },
+    },
+  );
   return response.data;
 };

--- a/src/events/types/CreateEventOptions.ts
+++ b/src/events/types/CreateEventOptions.ts
@@ -3,5 +3,7 @@ import { BaseEvent } from './BaseEvent';
 export type CreateEventOptions = Required<
   Pick<BaseEvent, 'scheduledTime' | 'payload' | 'destination'>
 > & {
-  disableEncryption?: boolean;
+  overrides?: {
+    encryption?: boolean;
+  };
 };

--- a/src/events/types/CreateEventOptions.ts
+++ b/src/events/types/CreateEventOptions.ts
@@ -2,4 +2,6 @@ import { BaseEvent } from './BaseEvent';
 
 export type CreateEventOptions = Required<
   Pick<BaseEvent, 'scheduledTime' | 'payload' | 'destination'>
->;
+> & {
+  disableEncryption?: boolean;
+};

--- a/src/middleware/webhookHandler.ts
+++ b/src/middleware/webhookHandler.ts
@@ -49,7 +49,7 @@ export const webhookHandler: WebhookHandler =
       return;
     }
 
-    if (!options?.disableEncryption) {
+    if (options?.overrides?.encryption !== false) {
       const config = getJiterConfig();
 
       if (config.encryption) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -14,11 +14,43 @@ export type OverrideJiterConfigOptions = {
   millisecondsUntilWebhookExpiration?: number;
 };
 
+export type EncryptionOptions<Key = string> = {
+  /**
+   * The encryption keys used to encrypt and decrypt data before sending it to Jiter.
+   *
+   * The last key in the array is the key used to encrypt new data. Old keys are used to decrypt data that was encrypted with that key.
+   */
+  keys: Array<{
+    /**
+     * The ID of the key, used to identify which key to use when encrypting/decrypting data.
+     *
+     * Must be unique within the array of keys and must not be changed once set.
+     *
+     * This will be sent with the encrypted data so that the correct key is used to decrypt data when it returns.
+     */
+    id: string;
+
+    /**
+     * The encryption key used to encrypt and decrypt data before sending it to Jiter and when it returns.
+     *
+     * Must be 32 bytes long encoded as hexadecimal. Keys should be generated with a cryptographically secure random byte generator.
+     */
+    key: Key;
+  }>;
+};
+
 export type JiterConfigOptions = {
   /**
    * @default {@link DEFAULT_TIMEOUT}
    */
   timeout?: number;
+
+  /**
+   * The encryption options used to encrypt and decrypt data before sending it to Jiter.
+   *
+   * @default null (No encryption)
+   */
+  encryption?: EncryptionOptions | null;
 };
 
 export type JiterConfig = {
@@ -35,4 +67,7 @@ export type JiterConfig = {
   signingSecret: string;
 } & JiterConfigOptions;
 
-export type JiterConfigInstance = Required<JiterConfig & OverrideJiterConfigOptions>;
+export type JiterConfigInstance = Omit<
+  Required<JiterConfig & OverrideJiterConfigOptions>,
+  'encryption'
+> & { encryption: EncryptionOptions<Buffer> | null };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,19 +1,3 @@
-export type OverrideJiterConfigOptions = {
-  /**
-   * @default {@link DEFAULT_URL}
-   */
-  baseUrl?: string;
-
-  /**
-   * The amount of milliseconds allowed between when a webhook event is sent and received before it becomes stale
-   *
-   * This value is used to help prevent Replay Attacks
-   *
-   * @default {@link DEFAULT_WEBHOOK_EXPIRATION_MILLISECONDS}
-   */
-  millisecondsUntilWebhookExpiration?: number;
-};
-
 export type EncryptionOptions<Key = string> = {
   /**
    * The encryption keys used to encrypt and decrypt data before sending it to Jiter.
@@ -39,21 +23,33 @@ export type EncryptionOptions<Key = string> = {
   }>;
 };
 
-export type JiterConfigOptions = {
+/**
+ * The options you can pass into init that are defaulted
+ */
+export interface DefaultedJiterConfig {
+  /**
+   * @default {@link DEFAULT_URL}
+   */
+  baseUrl?: string;
+
+  /**
+   * The amount of milliseconds allowed between when a webhook event is sent and received before it becomes stale
+   *
+   * This value is used to help prevent Replay Attacks
+   *
+   * @default {@link DEFAULT_WEBHOOK_EXPIRATION_MILLISECONDS}
+   */
+  millisecondsUntilWebhookExpiration?: number;
   /**
    * @default {@link DEFAULT_TIMEOUT}
    */
   timeout?: number;
+}
 
-  /**
-   * The encryption options used to encrypt and decrypt data before sending it to Jiter.
-   *
-   * @default null (No encryption)
-   */
-  encryption?: EncryptionOptions | null;
-};
-
-export type JiterConfig = {
+/**
+ * The options you can pass into init
+ */
+export interface JiterConfig extends DefaultedJiterConfig {
   /**
    * The API Key for your given org. Go to {@link https://app.jiter.dev/} to find your API Key
    */
@@ -65,9 +61,19 @@ export type JiterConfig = {
    * Go to {@link https://app.jiter.dev/} to find your Signing Secret
    */
   signingSecret: string;
-} & JiterConfigOptions;
 
-export type JiterConfigInstance = Omit<
-  Required<JiterConfig & OverrideJiterConfigOptions>,
-  'encryption'
-> & { encryption: EncryptionOptions<Buffer> | null };
+  /**
+   * The encryption options used to encrypt and decrypt data before sending it to Jiter.
+   *
+   * @default null (No encryption)
+   */
+  encryption?: EncryptionOptions;
+}
+
+/**
+ * The internal type of the options after being run through init
+ */
+export type JiterConfigInstance = Omit<JiterConfig, 'encryption'> &
+  Required<DefaultedJiterConfig> & {
+    encryption?: EncryptionOptions<Buffer>;
+  };

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -2,6 +2,7 @@ import type { NextFunction, Request } from 'express';
 
 export type WebhookHandlerOptions = {
   parse: false;
+  disableEncryption?: boolean;
 };
 
 export type WebhookHandlerWithParsingOptions = {

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -2,7 +2,9 @@ import type { NextFunction, Request } from 'express';
 
 export type WebhookHandlerOptions = {
   parse: false;
-  disableEncryption?: boolean;
+  overrides?: {
+    encryption?: boolean;
+  };
 };
 
 export type WebhookHandlerWithParsingOptions = {

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -1,0 +1,43 @@
+import crypto from 'crypto';
+import { getJiterConfig } from '../config';
+
+export const encrypt = (str: string): string => {
+  const config = getJiterConfig();
+  if (!config.encryption) throw new Error('Encryption Not Enabled');
+
+  const lastKey = config.encryption.keys.at(-1);
+  if (!lastKey) throw new Error('Missing Encryption Keys');
+
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', lastKey.key, iv);
+
+  const encryptedPayload = cipher.update(str, 'utf8', 'hex') + cipher.final('hex');
+
+  return Buffer.from(
+    [lastKey.id, iv.toString('hex'), cipher.getAuthTag().toString('hex'), encryptedPayload].join(
+      ':',
+    ),
+  ).toString('base64');
+};
+
+export const decrypt = (encrypted: string): string => {
+  const config = getJiterConfig();
+  if (!config.encryption) return encrypted;
+
+  const [id, iv, authTag, encryptedPayload] = Buffer.from(encrypted, 'base64')
+    .toString('utf8')
+    .split(':');
+
+  const decryptionKey = config.encryption.keys.find((k) => k.id === id);
+  if (!decryptionKey) throw new Error(`Missing Encryption Key: ${id}`);
+
+  const decipher = crypto.createDecipheriv(
+    'aes-256-gcm',
+    decryptionKey.key,
+    Buffer.from(iv, 'hex'),
+  );
+
+  decipher.setAuthTag(Buffer.from(authTag, 'hex'));
+
+  return decipher.update(encryptedPayload, 'hex', 'utf8') + decipher.final('utf8');
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './signatureIsValid';
+export * from './encryption';

--- a/tests/axios.test.ts
+++ b/tests/axios.test.ts
@@ -12,7 +12,6 @@ const mockConfig: JiterConfigInstance = {
   timeout: 1337,
   baseUrl: 'outer space',
   millisecondsUntilWebhookExpiration: 1000,
-  encryption: null,
 };
 
 describe('axios instance', () => {

--- a/tests/axios.test.ts
+++ b/tests/axios.test.ts
@@ -1,3 +1,4 @@
+import type { AxiosStatic } from 'axios';
 import { getJiterConfig } from '../src/config';
 import { JiterConfigInstance } from '../src/types/config';
 import { getMock } from './testUtils/getMock';
@@ -11,6 +12,7 @@ const mockConfig: JiterConfigInstance = {
   timeout: 1337,
   baseUrl: 'outer space',
   millisecondsUntilWebhookExpiration: 1000,
+  encryption: null,
 };
 
 describe('axios instance', () => {
@@ -20,7 +22,7 @@ describe('axios instance', () => {
 
   it('initializes with the correct config values', () => {
     jest.isolateModules(() => {
-      const axios = require('axios');
+      const axios: AxiosStatic = require('axios');
       const axiosCreateSpy = jest.spyOn(axios, 'create');
       const { getAxios } = jest.requireActual('../src/axios.ts');
 
@@ -44,7 +46,7 @@ describe('axios instance', () => {
 
   it('uses a cached instance when possible', () => {
     jest.isolateModules(() => {
-      const axios = require('axios');
+      const axios: AxiosStatic = require('axios');
       const axiosCreateSpy = jest.spyOn(axios, 'create');
       const { getAxios } = jest.requireActual('../src/axios.ts');
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,6 @@
 import { JiterInit } from '../src/config';
 import { DEFAULT_TIMEOUT, DEFAULT_URL } from '../src/consts';
-import { JiterConfigInstance } from '../src/types/config';
+import { EncryptionOptions, JiterConfigInstance } from '../src/types/config';
 
 type ConfigModule = {
   init: JiterInit;
@@ -32,7 +32,7 @@ describe('config', () => {
       });
     });
 
-    it('throws if an api key is not provided', () => {
+    it('throws if a signing secret is not provided', () => {
       jest.isolateModules(() => {
         const { init } = require('../src/config');
         expect(() => init({ apiKey: 'come on in' })).toThrow('Invalid Signing Secret');
@@ -45,6 +45,12 @@ describe('config', () => {
         expect(() => init({ apiKey: '       ', signingSecret: 'maple' })).toThrow(
           'Invalid API Key',
         );
+      });
+    });
+
+    it('throws if an signing secret is just whitespace', () => {
+      jest.isolateModules(() => {
+        const { init } = require('../src/config') as ConfigModule;
         expect(() => init({ apiKey: 'syrup', signingSecret: '       ' })).toThrow(
           'Invalid Signing Secret',
         );
@@ -66,6 +72,100 @@ describe('config', () => {
         expect(config.signingSecret).toEqual(signingSecret);
         expect(config.baseUrl).toEqual(overrideBaseUrl);
         expect(config.timeout).toEqual(overrideTimeout);
+      });
+    });
+
+    it('throws if an empty array is passed for encryption keys', () => {
+      jest.isolateModules(() => {
+        const { init } = require('../src/config') as ConfigModule;
+
+        const apiKey = 'no hax pls';
+        const signingSecret = 'seriously, no hax pls';
+        const encryptionOptions: EncryptionOptions = {
+          keys: [],
+        };
+
+        expect(() => init({ apiKey, signingSecret, encryption: encryptionOptions })).toThrow(
+          'Missing Encryption Keys',
+        );
+      });
+    });
+
+    it('throws if there are duplicate encryption key ids', () => {
+      jest.isolateModules(() => {
+        const { init } = require('../src/config') as ConfigModule;
+
+        const apiKey = 'no hax pls';
+        const signingSecret = 'seriously, no hax pls';
+        const encryptionOptions: EncryptionOptions = {
+          keys: [
+            {
+              id: 'one',
+              key: 'b61f10a074d9092284bab6b0e89a166886540b9156f590e1a20d274f57f5482a',
+            },
+            {
+              id: 'one',
+              key: '9c4536d376e92631fdebc0a376461b37e974c05d82613f48d302b15854f7e461',
+            },
+          ],
+        };
+
+        expect(() => init({ apiKey, signingSecret, encryption: encryptionOptions })).toThrow(
+          'Duplicate Key ID: one',
+        );
+      });
+    });
+
+    it('throws if an encryption key is not 32 bytes', () => {
+      jest.isolateModules(() => {
+        const { init } = require('../src/config') as ConfigModule;
+
+        const apiKey = 'no hax pls';
+        const signingSecret = 'seriously, no hax pls';
+        const encryptionOptions: EncryptionOptions = {
+          keys: [
+            {
+              id: 'one',
+              key: 'abc',
+            },
+          ],
+        };
+
+        expect(() => init({ apiKey, signingSecret, encryption: encryptionOptions })).toThrow(
+          'Invalid Key Length',
+        );
+      });
+    });
+
+    it('converts 32 byte hex keys into buffers correctly', () => {
+      jest.isolateModules(() => {
+        const { init, getJiterConfig } = require('../src/config') as ConfigModule;
+
+        const apiKey = 'no hax pls';
+        const signingSecret = 'seriously, no hax pls';
+        const encryptionOptions: EncryptionOptions = {
+          keys: [
+            {
+              id: 'one',
+              key: 'b61f10a074d9092284bab6b0e89a166886540b9156f590e1a20d274f57f5482a',
+            },
+            {
+              id: 'two',
+              key: '9c4536d376e92631fdebc0a376461b37e974c05d82613f48d302b15854f7e461',
+            },
+          ],
+        };
+
+        init({ apiKey, signingSecret, encryption: encryptionOptions });
+
+        const config = getJiterConfig();
+        expect(config.encryption).toBeDefined();
+        expect(config.encryption!.keys[0].key.toString('hex')).toEqual(
+          encryptionOptions.keys[0].key,
+        );
+        expect(config.encryption!.keys[1].key.toString('hex')).toEqual(
+          encryptionOptions.keys[1].key,
+        );
       });
     });
   });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,9 +1,9 @@
-import { JiterInit } from '../src/config';
+import { JiterInitFn } from '../src/config';
 import { DEFAULT_TIMEOUT, DEFAULT_URL } from '../src/consts';
 import { EncryptionOptions, JiterConfigInstance } from '../src/types/config';
 
 type ConfigModule = {
-  init: JiterInit;
+  init: JiterInitFn;
   getJiterConfig: () => JiterConfigInstance;
 };
 

--- a/tests/events/createEvent.test.ts
+++ b/tests/events/createEvent.test.ts
@@ -85,7 +85,6 @@ describe('Events.createEvent', () => {
       signingSecret: 'signing-secret',
       millisecondsUntilWebhookExpiration: 0,
       timeout: 0,
-      encryption: null,
     });
 
     const mockData: Partial<BaseEvent> = { id: 'hello world' };

--- a/tests/events/createEvent.test.ts
+++ b/tests/events/createEvent.test.ts
@@ -1,10 +1,34 @@
-import Jiter, { BaseEvent } from '../../src';
+import { AxiosRequestTransformer } from 'axios';
+import Jiter, { BaseEvent, encrypt } from '../../src';
 import { eventsPath } from '../../src/events/consts';
 import { mockGetAxios } from '../testUtils/getAxiosMock';
+import { getMock } from '../testUtils/getMock';
+import { getJiterConfig } from '../../src/config';
+
+jest.mock('../../src/config.ts');
+const getJiterConfigMock = getMock(getJiterConfig);
+
+jest.mock('../../src/utils/encryption.ts');
+const encryptMock = getMock(encrypt);
 
 const getAxiosMock = mockGetAxios();
 
+getJiterConfigMock.mockReturnValue({
+  apiKey: 'api-key',
+  baseUrl: 'base-url',
+  signingSecret: 'signing-secret',
+  millisecondsUntilWebhookExpiration: 0,
+  timeout: 0,
+  encryption: {
+    keys: [],
+  },
+});
+
 describe('Events.createEvent', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('creates an event in an hour', async () => {
     const mockData: Partial<BaseEvent> = { id: 'hello world' };
     getAxiosMock.post.mockReturnValueOnce({ data: mockData });
@@ -20,7 +44,104 @@ describe('Events.createEvent', () => {
     expect(getAxiosMock.post).toHaveBeenCalledWith(
       eventsPath,
       expect.objectContaining({ ...createEventOptions }),
+      expect.objectContaining({ transformRequest: expect.any(Function) }),
     );
     expect(response).toBe(mockData);
+  });
+
+  it('creates an event with the encrypt utility', async () => {
+    const mockData: Partial<BaseEvent> = { id: 'hello world' };
+    getAxiosMock.post.mockReturnValueOnce({ data: mockData });
+
+    const createEventOptions = {
+      payload: 'beep',
+      scheduledTime: new Date(Date.now() + 800).toISOString(),
+      destination: 'https://your.app/webhooks',
+    };
+    await Jiter.Events.createEvent(createEventOptions);
+
+    expect(getAxiosMock.post).toHaveBeenCalledTimes(1);
+    expect(getAxiosMock.post).toHaveBeenCalledWith(
+      eventsPath,
+      expect.objectContaining({ ...createEventOptions }),
+      expect.objectContaining({ transformRequest: expect.any(Function) }),
+    );
+
+    const transformRequest = getAxiosMock.post.mock.lastCall![2]!
+      .transformRequest as AxiosRequestTransformer;
+
+    const mockEncryptedPayload = 'encrypted';
+    encryptMock.mockReturnValue(mockEncryptedPayload);
+    const { payload: encryptedPayload } = transformRequest(createEventOptions);
+
+    expect(encryptMock).toHaveBeenCalledWith(createEventOptions.payload);
+    expect(encryptedPayload).toEqual(mockEncryptedPayload);
+  });
+
+  it('skips encryption if encryption is disabled in the config', async () => {
+    getJiterConfigMock.mockReturnValue({
+      apiKey: 'api-key',
+      baseUrl: 'base-url',
+      signingSecret: 'signing-secret',
+      millisecondsUntilWebhookExpiration: 0,
+      timeout: 0,
+      encryption: null,
+    });
+
+    const mockData: Partial<BaseEvent> = { id: 'hello world' };
+    getAxiosMock.post.mockReturnValueOnce({ data: mockData });
+
+    const createEventOptions = {
+      payload: 'beep',
+      scheduledTime: new Date(Date.now() + 800).toISOString(),
+      destination: 'https://your.app/webhooks',
+    };
+    await Jiter.Events.createEvent(createEventOptions);
+
+    expect(getAxiosMock.post).toHaveBeenCalledTimes(1);
+    expect(getAxiosMock.post).toHaveBeenCalledWith(
+      eventsPath,
+      expect.objectContaining({ ...createEventOptions }),
+      expect.objectContaining({ transformRequest: expect.any(Function) }),
+    );
+
+    const transformRequest = getAxiosMock.post.mock.lastCall![2]!
+      .transformRequest as AxiosRequestTransformer;
+
+    const mockEncryptedPayload = 'encrypted';
+    encryptMock.mockReturnValue(mockEncryptedPayload);
+    const transformedData = transformRequest(createEventOptions);
+
+    expect(encryptMock).not.toHaveBeenCalled();
+    expect(transformedData).toBe(createEventOptions);
+  });
+
+  it('skips encryption if the option disableEncryption is true', async () => {
+    const mockData: Partial<BaseEvent> = { id: 'hello world' };
+    getAxiosMock.post.mockReturnValueOnce({ data: mockData });
+
+    const createEventOptions = {
+      payload: 'beep',
+      scheduledTime: new Date(Date.now() + 800).toISOString(),
+      destination: 'https://your.app/webhooks',
+    };
+    await Jiter.Events.createEvent({ ...createEventOptions, disableEncryption: true });
+
+    expect(getAxiosMock.post).toHaveBeenCalledTimes(1);
+    expect(getAxiosMock.post).toHaveBeenCalledWith(
+      eventsPath,
+      expect.objectContaining({ ...createEventOptions }),
+      expect.objectContaining({ transformRequest: expect.any(Function) }),
+    );
+
+    const transformRequest = getAxiosMock.post.mock.lastCall![2]!
+      .transformRequest as AxiosRequestTransformer;
+
+    const mockEncryptedPayload = 'encrypted';
+    encryptMock.mockReturnValue(mockEncryptedPayload);
+    const transformedData = transformRequest(createEventOptions);
+
+    expect(encryptMock).not.toHaveBeenCalled();
+    expect(transformedData).toBe(createEventOptions);
   });
 });

--- a/tests/events/createEvent.test.ts
+++ b/tests/events/createEvent.test.ts
@@ -115,7 +115,7 @@ describe('Events.createEvent', () => {
     expect(transformedData).toBe(createEventOptions);
   });
 
-  it('skips encryption if the option disableEncryption is true', async () => {
+  it('skips encryption if the option encryption override is false', async () => {
     const mockData: Partial<BaseEvent> = { id: 'hello world' };
     getAxiosMock.post.mockReturnValueOnce({ data: mockData });
 
@@ -124,7 +124,7 @@ describe('Events.createEvent', () => {
       scheduledTime: new Date(Date.now() + 800).toISOString(),
       destination: 'https://your.app/webhooks',
     };
-    await Jiter.Events.createEvent({ ...createEventOptions, disableEncryption: true });
+    await Jiter.Events.createEvent({ ...createEventOptions, overrides: { encryption: false } });
 
     expect(getAxiosMock.post).toHaveBeenCalledTimes(1);
     expect(getAxiosMock.post).toHaveBeenCalledWith(

--- a/tests/middleware/webhookHandler.test.ts
+++ b/tests/middleware/webhookHandler.test.ts
@@ -27,10 +27,7 @@ const baseJiterConfig = {
   millisecondsUntilWebhookExpiration: 0,
   timeout: 0,
 };
-mockGetJiterConfig.mockReturnValue({
-  ...baseJiterConfig,
-  encryption: null,
-});
+mockGetJiterConfig.mockReturnValue(baseJiterConfig);
 
 const mockRes: Pick<Response, 'sendStatus'> = {
   sendStatus: jest.fn(),

--- a/tests/middleware/webhookHandler.test.ts
+++ b/tests/middleware/webhookHandler.test.ts
@@ -4,12 +4,33 @@ import { REQUEST_TIMESTAMP_HEADER, SIGNATURE_HEADER } from '../../src/consts';
 import { webhookHandler } from '../../src/middleware/webhookHandler';
 import { signatureIsValid } from '../../src/utils/signatureIsValid';
 import { getMock } from '../testUtils/getMock';
+import { decrypt } from '../../src/utils/encryption';
+import { getJiterConfig } from '../../src/config';
 
 const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
 jest.mock('../../src/utils/signatureIsValid');
 const mockSignatureIsValid = getMock(signatureIsValid);
 mockSignatureIsValid.mockReturnValue(true);
+
+jest.mock('../../src/utils/encryption.ts');
+const mockDecrypt = getMock(decrypt);
+const decryptMockReturnValue = 'decrypted payload';
+mockDecrypt.mockReturnValue(decryptMockReturnValue);
+
+jest.mock('../../src/config.ts');
+const mockGetJiterConfig = getMock(getJiterConfig);
+const baseJiterConfig = {
+  apiKey: 'api-key',
+  baseUrl: 'base-url',
+  signingSecret: 'signing-secret',
+  millisecondsUntilWebhookExpiration: 0,
+  timeout: 0,
+};
+mockGetJiterConfig.mockReturnValue({
+  ...baseJiterConfig,
+  encryption: null,
+});
 
 const mockRes: Pick<Response, 'sendStatus'> = {
   sendStatus: jest.fn(),
@@ -87,6 +108,86 @@ describe('validateWebhook middleware', () => {
     expect(mockCallback).toBeCalledTimes(1);
     expect(mockRes.sendStatus).toBeCalledTimes(1);
     expect(mockRes.sendStatus).toBeCalledWith(200);
+  });
+
+  it('skips decryption if disableEncryption option is true', () => {
+    const mockReq: MockRequest = {
+      body: {},
+      header: mockHeaderMethod,
+    };
+
+    const mockCallback = jest.fn();
+    webhookHandler(mockCallback, { parse: false, disableEncryption: true })(
+      mockReq as Request,
+      mockRes as Response,
+      mockNext,
+    );
+
+    expect(mockGetJiterConfig).not.toHaveBeenCalled();
+    expect(mockDecrypt).not.toHaveBeenCalled();
+  });
+
+  it('skips decryption if encryption is not enabled', () => {
+    const mockReq: MockRequest = {
+      body: {},
+      header: mockHeaderMethod,
+    };
+
+    const mockCallback = jest.fn();
+    webhookHandler(mockCallback)(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockDecrypt).not.toHaveBeenCalled();
+  });
+
+  it('returns a 500 status if decryption throws', () => {
+    const mockReq: MockRequest = {
+      body: {},
+      header: mockHeaderMethod,
+    };
+
+    mockGetJiterConfig.mockReturnValueOnce({
+      ...baseJiterConfig,
+      encryption: {
+        keys: [],
+      },
+    });
+
+    mockDecrypt.mockImplementationOnce(() => {
+      throw new Error();
+    });
+
+    const mockCallback = jest.fn();
+    webhookHandler(mockCallback)(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockCallback).not.toBeCalled();
+    expect(mockRes.sendStatus).toBeCalledTimes(1);
+    expect(mockRes.sendStatus).toBeCalledWith(500);
+  });
+
+  it('decrypts the payload if encryption is enabled', () => {
+    const mockReq: MockRequest = {
+      body: {},
+      header: mockHeaderMethod,
+    };
+
+    mockGetJiterConfig.mockReturnValueOnce({
+      ...baseJiterConfig,
+      encryption: {
+        keys: [],
+      },
+    });
+
+    const mockCallback = jest.fn();
+    webhookHandler(mockCallback)(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockCallback).toBeCalledTimes(1);
+    expect(mockCallback).toBeCalledWith(
+      expect.objectContaining({ payload: decryptMockReturnValue }),
+    );
+    expect(mockRes.sendStatus).toBeCalledTimes(1);
+    expect(mockRes.sendStatus).toBeCalledWith(200);
+    expect(mockDecrypt).toBeCalledTimes(1);
+    expect(mockDecrypt).toBeCalledWith(mockReq.body.payload);
   });
 
   describe('response variations', () => {

--- a/tests/middleware/webhookHandler.test.ts
+++ b/tests/middleware/webhookHandler.test.ts
@@ -107,14 +107,14 @@ describe('validateWebhook middleware', () => {
     expect(mockRes.sendStatus).toBeCalledWith(200);
   });
 
-  it('skips decryption if disableEncryption option is true', () => {
+  it('skips decryption if encryption override option is false', () => {
     const mockReq: MockRequest = {
       body: {},
       header: mockHeaderMethod,
     };
 
     const mockCallback = jest.fn();
-    webhookHandler(mockCallback, { parse: false, disableEncryption: true })(
+    webhookHandler(mockCallback, { parse: false, overrides: { encryption: false } })(
       mockReq as Request,
       mockRes as Response,
       mockNext,

--- a/tests/utils/encryption.test.ts
+++ b/tests/utils/encryption.test.ts
@@ -1,0 +1,99 @@
+import crypto from 'crypto';
+import { getJiterConfig } from '../../src/config';
+import { JiterConfigInstance } from '../../src/types/config';
+import { encrypt, decrypt } from '../../src/utils/encryption';
+import { getMock } from '../testUtils/getMock';
+
+jest.mock('../../src/config.ts');
+const getJiterConfigMock = getMock(getJiterConfig);
+
+const mockConfigBase: Omit<JiterConfigInstance, 'encryption'> = {
+  apiKey: 'api-key',
+  baseUrl: 'base-url',
+  signingSecret: 'signing-secret',
+  millisecondsUntilWebhookExpiration: 0,
+  timeout: 0,
+};
+
+const mockRandomBytes = '84259b23b50b952191d3c66c';
+const input = 'hello world';
+const encryptionKeyId = 'one';
+const encryptionKey = 'b61f10a074d9092284bab6b0e89a166886540b9156f590e1a20d274f57f5482a';
+const encryptedPayload =
+  'b25lOjg0MjU5YjIzYjUwYjk1MjE5MWQzYzY2YzphNWM1ZjUzNTY3NzU2NzI5NDFiZDkzZTdlMTNjYTQ2MzplMzhiY2YyZWZhYjRiMDdlOWVhYzRi';
+
+jest.spyOn(crypto, 'randomBytes').mockImplementation(() => Buffer.from(mockRandomBytes, 'hex'));
+
+describe('Encryption Utils', () => {
+  it('encrypt throws if encryption is not enabled', async () => {
+    getJiterConfigMock.mockReturnValue({
+      ...mockConfigBase,
+      encryption: null,
+    });
+
+    expect(() => encrypt(input)).toThrow('Encryption Not Enabled');
+  });
+
+  it('encrypt throws if there are no encryption keys', async () => {
+    getJiterConfigMock.mockReturnValue({
+      ...mockConfigBase,
+      encryption: {
+        keys: [],
+      },
+    });
+
+    expect(() => encrypt('hello world')).toThrow('Missing Encryption Keys');
+  });
+
+  it('encrypt returns the encrypted string encoded as base64', () => {
+    getJiterConfigMock.mockReturnValue({
+      ...mockConfigBase,
+      encryption: {
+        keys: [
+          {
+            id: encryptionKeyId,
+            key: Buffer.from(encryptionKey, 'hex'),
+          },
+        ],
+      },
+    });
+
+    expect(encrypt(input)).toEqual(encryptedPayload);
+  });
+
+  it('decrypt returns the input if encryption is not enabled', () => {
+    getJiterConfigMock.mockReturnValue({
+      ...mockConfigBase,
+      encryption: null,
+    });
+
+    expect(decrypt(input)).toEqual(input);
+  });
+
+  it('decrypt throws if the encryption key is missing', () => {
+    getJiterConfigMock.mockReturnValue({
+      ...mockConfigBase,
+      encryption: {
+        keys: [],
+      },
+    });
+
+    expect(() => decrypt(encryptedPayload)).toThrow(`Missing Encryption Key: ${encryptionKeyId}`);
+  });
+
+  it('decrypt returns the decrypted string', () => {
+    getJiterConfigMock.mockReturnValue({
+      ...mockConfigBase,
+      encryption: {
+        keys: [
+          {
+            id: encryptionKeyId,
+            key: Buffer.from(encryptionKey, 'hex'),
+          },
+        ],
+      },
+    });
+
+    expect(decrypt(encryptedPayload)).toEqual(input);
+  });
+});

--- a/tests/utils/encryption.test.ts
+++ b/tests/utils/encryption.test.ts
@@ -15,6 +15,9 @@ const mockConfigBase: Omit<JiterConfigInstance, 'encryption'> = {
   timeout: 0,
 };
 
+/** Encryption Test Notes
+ * All of these are real values, do not change them! If they are changed they must be generated with the Crypto library again so that the encryption/decryption tests function correctly
+ */
 const mockRandomBytes = '84259b23b50b952191d3c66c';
 const input = 'hello world';
 const encryptionKeyId = 'one';

--- a/tests/utils/encryption.test.ts
+++ b/tests/utils/encryption.test.ts
@@ -26,10 +26,7 @@ jest.spyOn(crypto, 'randomBytes').mockImplementation(() => Buffer.from(mockRando
 
 describe('Encryption Utils', () => {
   it('encrypt throws if encryption is not enabled', async () => {
-    getJiterConfigMock.mockReturnValue({
-      ...mockConfigBase,
-      encryption: null,
-    });
+    getJiterConfigMock.mockReturnValue(mockConfigBase);
 
     expect(() => encrypt(input)).toThrow('Encryption Not Enabled');
   });
@@ -62,10 +59,7 @@ describe('Encryption Utils', () => {
   });
 
   it('decrypt returns the input if encryption is not enabled', () => {
-    getJiterConfigMock.mockReturnValue({
-      ...mockConfigBase,
-      encryption: null,
-    });
+    getJiterConfigMock.mockReturnValue(mockConfigBase);
 
     expect(decrypt(input)).toEqual(input);
   });


### PR DESCRIPTION
### Description of Changes
- Adds encryption using `aes-256-gcm` (with options to disable on both the create event utility and middleware)
- Supports multiple keys so end users can rotate in new keys while still decrypting with old keys

**To-Do**
- [ ] Update README
- [ ] Add encryption page to [Docs repo](https://github.com/Pantheon-Labs/Jiter-Docs)

### Related Issues
<!-- Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
Closes #16 
